### PR TITLE
feat(confirm-delete-dialog): add confirmation dialog for product deletion

### DIFF
--- a/cypress/e2e/delete-product.cy.ts
+++ b/cypress/e2e/delete-product.cy.ts
@@ -1,0 +1,74 @@
+describe('Delete Product Functionality', () => {
+  beforeEach(() => {
+    cy.visit('http://localhost:4200');
+    cy.wait(1000); // wait for the page to load
+  });
+
+  it('should open delete confirmation dialog when clicking delete button', () => {
+    // click on the first delete button
+    cy.get('tbody tr').first().within(() => {
+      cy.get('button').last().click();
+    });
+
+    // check if dialog is open
+    cy.get('mat-dialog-container').should('be.visible');
+    cy.get('mat-dialog-content').should('contain', 'Are you sure you want to delete');
+  });
+
+  it('should close dialog when clicking cancel', () => {
+    // open delete dialog
+    cy.get('tbody tr').first().within(() => {
+      cy.get('button').last().click();
+    });
+
+    cy.get('button').contains('Cancel').click();
+    cy.get('mat-dialog-container').should('not.exist');
+  });
+
+  it('should show loading state and success message when deleting', () => {
+    // open delete dialog
+    cy.get('tbody tr').first().within(() => {
+      cy.get('button').last().click();
+    });
+
+    // store initial number of rows
+    cy.get('tbody tr').its('length').then((initialRows) => {
+      // confirm delete
+      cy.get('button').contains('Delete').click();
+
+      // check loading state
+      cy.get('mat-spinner').should('be.visible');
+      cy.get('p').contains('Deleting product...').should('be.visible');
+
+      // check success message
+      cy.get('h2').contains('Success').should('be.visible');
+      cy.get('mat-dialog-content').contains('Successfully deleted').should('be.visible');
+
+      // Verificar que se eliminó la fila
+      cy.get('tbody tr').should('have.length', initialRows - 1);
+    });
+  });
+
+  it('should handle error state when delete fails', () => {
+    // simulate error response
+    cy.intercept('DELETE', '**/products/*', {
+      statusCode: 500,
+      body: { error: 'Server error' }
+    }).as('deleteError');
+
+    // open delete dialog
+    cy.get('tbody tr').first().within(() => {
+      cy.get('button').last().click();
+    });
+
+    // confirm delete
+    cy.get('button').contains('Delete').click();
+
+    // verify error state
+    cy.wait('@deleteError');
+    cy.get('h2').contains('Error').should('be.visible');
+    cy.get('mat-dialog-content')
+      .contains('There was a problem, please try again later')
+      .should('be.visible');
+  });
+});

--- a/src/app/components/confirm-delete-dialog/confirm-delete-dialog.component.css
+++ b/src/app/components/confirm-delete-dialog/confirm-delete-dialog.component.css
@@ -1,0 +1,9 @@
+.loading-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 20px;
+  }
+  .loading-container p {
+    margin-top: 16px;
+  }

--- a/src/app/components/confirm-delete-dialog/confirm-delete-dialog.component.spec.ts
+++ b/src/app/components/confirm-delete-dialog/confirm-delete-dialog.component.spec.ts
@@ -1,0 +1,99 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ConfirmDeleteDialogComponent } from './confirm-delete-dialog.component';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import mockProductData from '../../fixtures/mock-products.json';
+import { Product, ProductService } from '../../services/product.service';
+import { of, throwError } from 'rxjs';
+
+describe('ConfirmDeleteDialogComponent', () => {
+  let component: ConfirmDeleteDialogComponent;
+  let fixture: ComponentFixture<ConfirmDeleteDialogComponent>;
+  let dialogRef: jasmine.SpyObj<MatDialogRef<ConfirmDeleteDialogComponent>>;
+  let productServiceMock: jasmine.SpyObj<ProductService>;
+  
+  const mockProduct: Product = mockProductData.products[0];
+
+  beforeEach(async () => {
+    dialogRef = jasmine.createSpyObj('MatDialogRef', ['close', 'disableClose']);
+    productServiceMock = jasmine.createSpyObj('ProductService', ['deleteProduct']);
+
+    await TestBed.configureTestingModule({
+      imports: [
+        ConfirmDeleteDialogComponent,
+        BrowserAnimationsModule
+      ],
+      providers: [
+        { provide: MatDialogRef, useValue: dialogRef },
+        { provide: MAT_DIALOG_DATA, useValue: mockProduct },
+        { provide: ProductService, useValue: productServiceMock }
+      ]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ConfirmDeleteDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should show product title in confirmation message', () => {
+    const content = fixture.nativeElement.querySelector('mat-dialog-content');
+    expect(content.textContent).toContain(mockProduct.title);
+  });
+
+  it('should emit confirmed event and show loading on confirm', () => {
+    productServiceMock.deleteProduct.and.returnValue(of(mockProduct));
+    spyOn(component.confirmed, 'emit');
+    
+    component.onConfirm();
+    expect(component.isDeleting).toBe(true);
+    expect(dialogRef.disableClose).toBe(true);
+    expect(component.confirmed.emit).toHaveBeenCalled();
+  });
+
+  it('should handle failed product deletion', () => {
+    productServiceMock.deleteProduct.and.returnValue(throwError(() => new Error('Error')));
+    
+    component.onConfirm();
+    component.setComplete(false);
+    
+    expect(component.isDeleting).toBe(false);
+    expect(component.hasError).toBe(true);
+    expect(component.isCompleted).toBe(false);
+    expect(dialogRef.disableClose).toBe(false);
+  });
+
+  it('should close dialog with false on cancel', () => {
+    component.onCancel();
+    expect(dialogRef.close).toHaveBeenCalledWith(false);
+  });
+
+  it('should handle successful completion', () => {
+    component.setComplete(true);
+    
+    expect(component.isDeleting).toBe(false);
+    expect(component.isCompleted).toBe(true);
+    expect(component.hasError).toBe(false);
+    expect(dialogRef.disableClose).toBe(false);
+  });
+
+  it('should handle error completion', () => {
+    component.setComplete(false);
+    
+    expect(component.isDeleting).toBe(false);
+    expect(component.isCompleted).toBe(false);
+    expect(component.hasError).toBe(true);
+    expect(dialogRef.disableClose).toBe(false);
+  });
+
+  it('should close dialog with completion status on close', () => {
+    component.isCompleted = true;
+    component.onClose();
+    expect(dialogRef.close).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/app/components/confirm-delete-dialog/confirm-delete-dialog.component.ts
+++ b/src/app/components/confirm-delete-dialog/confirm-delete-dialog.component.ts
@@ -1,0 +1,100 @@
+import { Component, Inject, EventEmitter } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { Product } from '../../services/product.service';
+
+@Component({
+  selector: 'app-confirm-delete-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatDialogModule,
+    MatButtonModule,
+    MatProgressSpinnerModule
+  ],
+  template: `
+    <div *ngIf="!isDeleting && !isCompleted && !hasError">
+      <h2 mat-dialog-title>Confirm Deletion</h2>
+      <mat-dialog-content>
+        Are you sure you want to delete the product "{{data.title}}"?
+      </mat-dialog-content>
+      <mat-dialog-actions align="end">
+        <button mat-button (click)="onCancel()">Cancel</button>
+        <button mat-flat-button color="warn" (click)="onConfirm()">Delete</button>
+      </mat-dialog-actions>
+    </div>
+
+    <div *ngIf="isDeleting" class="loading-container">
+      <mat-spinner diameter="50"></mat-spinner>
+      <p>Deleting product...</p>
+    </div>
+
+    <div *ngIf="isCompleted">
+      <h2 mat-dialog-title>Success</h2>
+      <mat-dialog-content>
+        Successfully deleted
+      </mat-dialog-content>
+      <mat-dialog-actions align="end">
+        <button mat-button (click)="onClose()">Accept</button>
+      </mat-dialog-actions>
+    </div>
+
+    <div *ngIf="hasError">
+      <h2 mat-dialog-title>Error</h2>
+      <mat-dialog-content>
+        There was a problem, please try again later
+      </mat-dialog-content>
+      <mat-dialog-actions align="end">
+        <button mat-button (click)="onClose()">Accept</button>
+      </mat-dialog-actions>
+    </div>
+  `,
+  styles: [`
+    .loading-container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 20px;
+    }
+    .loading-container p {
+      margin-top: 16px;
+    }
+  `]
+})
+export class ConfirmDeleteDialogComponent {
+  isDeleting = false;
+  isCompleted = false;
+  hasError = false;
+  confirmed = new EventEmitter<void>();
+
+  constructor(
+    public dialogRef: MatDialogRef<ConfirmDeleteDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: Product
+  ) {}
+
+  onCancel(): void {
+    this.dialogRef.close(false);
+  }
+
+  onConfirm(): void {
+    this.isDeleting = true;
+    this.dialogRef.disableClose = true;
+    this.confirmed.emit();
+  }
+
+  onClose(): void {
+    this.dialogRef.close(this.isCompleted);
+  }
+
+  setComplete(success: boolean): void {
+    this.isDeleting = false;
+    if (success) {
+      this.isCompleted = true;
+    } else {
+      this.hasError = true;
+    }
+    this.dialogRef.disableClose = false;
+  }
+}

--- a/src/app/components/data-table/data-table.component.spec.ts
+++ b/src/app/components/data-table/data-table.component.spec.ts
@@ -8,6 +8,7 @@ import { ActionButtonComponent } from '../action-button/action-button.component'
 import { PageEvent } from '@angular/material/paginator';
 import mockProductData from '../../fixtures/mock-products.json';
 import { EventEmitter } from '@angular/core';
+import { By } from '@angular/platform-browser';
 
 describe('DataTableComponent', () => {
   let component: DataTableComponent;
@@ -16,20 +17,18 @@ describe('DataTableComponent', () => {
   let routerMock: jasmine.SpyObj<Router>;
 
   beforeEach(waitForAsync(() => {
-    productServiceMock = jasmine.createSpyObj('ProductService', ['getProducts', 'searchProducts']);
+    productServiceMock = jasmine.createSpyObj('ProductService', ['getProducts', 'searchProducts', 'deleteProduct']);
     routerMock = jasmine.createSpyObj('Router', ['navigate']);
 
     TestBed.configureTestingModule({
       imports: [
         NoopAnimationsModule,
-        // DataTableComponent is standalone. Needs to import dependencies(Material modules, ReactiveFormsModule).
-        // ActionButtonComponent is standalone. Needs DataTableComponent.
         DataTableComponent,
-        ActionButtonComponent
+        ActionButtonComponent,
       ],
       providers: [
         { provide: ProductService, useValue: productServiceMock },
-        { provide: Router, useValue: routerMock }
+        { provide: Router, useValue: routerMock },
       ]
     }).compileComponents();
   }));
@@ -50,7 +49,8 @@ describe('DataTableComponent', () => {
       hasPreviousPage: () => false
     } as any;
 
-    fixture.detectChanges();
+    // ngOnInit is executed here
+    fixture.detectChanges(); 
   });
 
   afterEach(() => {
@@ -88,7 +88,7 @@ describe('DataTableComponent', () => {
 
   it('should handle page event', () => {
     // Event page simualted
-    const pageEvent: PageEvent = { pageIndex: 1, pageSize: 5, length: mockProductData.total }; // <--- Usa mockProductData
+    const pageEvent: PageEvent = { pageIndex: 1, pageSize: 5, length: mockProductData.total };
     component.handlePageEvent(pageEvent);
 
     expect(component.paginator.pageIndex).toBe(1);
@@ -111,8 +111,12 @@ describe('DataTableComponent', () => {
     expect(routerMock.navigate).toHaveBeenCalledWith(['/edit', mockProductData.products[0].id]);
   });
 
-  it('should navigate on delete', () => {
-    component.onDelete(mockProductData.products[1]);
-    expect(routerMock.navigate).toHaveBeenCalledWith(['/delete', mockProductData.products[1].id]);
+  it('should have a delete button', () => {
+    fixture.detectChanges();
+    // find the ActionButtonComponent
+    const actionButtons = fixture.debugElement.queryAll(By.directive(ActionButtonComponent));
+    // check delete button exists
+    const deleteButtonDebug = actionButtons.find(debugEl => debugEl.componentInstance.icon === 'delete');
+    expect(deleteButtonDebug).toBeTruthy();
   });
 });

--- a/src/app/services/product.service.ts
+++ b/src/app/services/product.service.ts
@@ -51,4 +51,8 @@ export class ProductService {
       `${this.baseUrl}/search?q=${query}&${queryParams}`
     );
   }
+
+  deleteProduct(id: number): Observable<Product> {
+    return this.http.delete<Product>(`${this.baseUrl}/${id}`);
+  }
 }


### PR DESCRIPTION
Implement a confirmation dialog to ensure users confirm before deleting a product. The dialog includes loading, success, and error states to provide feedback during the deletion process. This improves user experience by preventing accidental deletions and providing clear feedback.